### PR TITLE
Updates for GPG checks and duplicate downloads

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,12 +70,12 @@
   when: ansible_os_family == "Debian"
   tags: sumologic
 
-- name: 'Download SumoCollector redhat'
-  get_url:
-    url: '{{ sumocollector_installer_rpm }}'
-    dest: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
-  when: ansible_os_family == "RedHat"
-  tags: sumologic
+# - name: 'Download SumoCollector redhat'
+#   get_url:
+#     url: '{{ sumocollector_installer_rpm }}'
+#     dest: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
+#   when: ansible_os_family == "RedHat"
+#   tags: sumologic
 
 - name: 'Define initial SumoCollector sources'
   set_fact:

--- a/tasks/native_install.yml
+++ b/tasks/native_install.yml
@@ -7,7 +7,9 @@
     dest: /root/SumoCollector.sh
     mode: '0700'
   register: dl_result
+  when: sumologic_token_installer is defined
   until: dl_result is success
+
 
 - name: Install sumo with sumo installer
   command: >
@@ -61,6 +63,7 @@
   yum:
     name: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
     state: present
+    disable_gpg_check: true
   when: ( sumologic_collector_yum_check.rc == 1 ) and ( ansible_os_family == "RedHat" )
   tags: [sumologic, sumologic_force_restart]
   notify: Restart SumoCollector


### PR DESCRIPTION
Stop downloading SumoLogic.sh if it isn't needed 
disable GPG check on yum install
only run SumoCollector.sh if sumologic_token_installer is defined.